### PR TITLE
Ansible Updates for Initial `pt.mabl.se` Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Hostname-Port Allocations
 | `www.mkdevops.se`          | `8073` | www.mkdevops.se WordPress site                 |
 | `staging-www.mkdevops.se`  | `8074` | www.mkdevops.se WordPress staging site         |
 | `bamboo.mkdevops.se`       | `8085` | Test server for `mkdevops-se/bamboo-ci-health` |
+| `pt.mabl.se`               | `9000` | Test server for video streaming                |
 | `konfigurator.mkdevops.se` | `3000` | See `mkdevops-se/konfigurator` project         |
 | `kibana.mkdevops.se`       | `5601` | Kibana setup for Titan-Elastic                 |
 

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -30,6 +30,10 @@
         - name: bamboo.mkdevops.se
           local_port: 8085
 
+        - name: pt.mabl.se
+          local_port: 9000
+          max_upload_size: 512M
+
         - name: konfigurator.mkdevops.se
           local_port: 3000
           max_upload_size: 16M


### PR DESCRIPTION
Along with this Nginx provisioning code change, PT is built and deployed per the [instruction here](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/docker.md) using Docker.

My `/opt/pt/PeerTube/docker-compose.yml`:

```yaml
version: "3.3"

services:

  # You can comment this webserver section if you want to use another webserver/proxy or test PeerTube in local
  #webserver:
  #  image: chocobozzz/peertube-webserver:latest
  #  # If you don't want to use the official image and build one from sources:
  #  # build:
  #  #   context: .
  #  #   dockerfile: Dockerfile.nginx
  #  env_file:
  #    - .env
  #  ports:
  #   - "80:80"
  #   - "443:443"
  #  volumes:
  #    - type: bind
  #      # Switch sources if you downloaded the whole repository
  #      #source: ../../nginx/peertube
  #      source: ./docker-volume/nginx/peertube
  #      target: /etc/nginx/conf.d/peertube.template
  #    - assets:/var/www/peertube/peertube-latest/client/dist:ro
  #    - ./docker-volume/data:/var/www/peertube/storage
  #    - certbot-www:/var/www/certbot
  #    - ./docker-volume/certbot/conf:/etc/letsencrypt
  #  depends_on:
  #    - peertube
  #  restart: "always"

  # You can comment this certbot section if you want to use another webserver/proxy or test PeerTube in local
  #certbot:
  #  container_name: certbot
  #  image: certbot/certbot
  #  volumes:
  #    - ./docker-volume/certbot/conf:/etc/letsencrypt
  #    - certbot-www:/var/www/certbot
  #  restart: unless-stopped
  #  entrypoint: /bin/sh -c "trap exit TERM; while :; do certbot renew --webroot -w /var/www/certbot; sleep 12h & wait $${!}; done;"
  #  depends_on:
  #    - webserver

  peertube:
    # If you don't want to use the official image and build one from sources:
    build:
      context: .
      dockerfile: ./support/docker/production/Dockerfile.bullseye
    #image: chocobozzz/peertube:production-bullseye
    # Use a static IP for this container because nginx does not handle proxy host change without reload
    # This container could be restarted on crash or until the postgresql database is ready for connection
    #networks:
    #  default:
    #    ipv4_address: 172.18.0.42
    env_file:
      - .env

    ports:
     - "1935:1935" # Comment if you don't want to use the live feature
     - "9000:9000" # Uncomment if you use another webserver/proxy or test PeerTube in local, otherwise not suitable for production
    volumes:
      - assets:/app/client/dist
      - ./docker-volume/data:/data
      - ./docker-volume/config:/config
    depends_on:
      - postgres
      - redis
      - postfix
    restart: "always"

  postgres:
    image: postgres:13-alpine
    env_file:
      - .env
    volumes:
      - ./docker-volume/db:/var/lib/postgresql/data
    restart: "always"

  redis:
    image: redis:6-alpine
    volumes:
      - ./docker-volume/redis:/data
    restart: "always"

  postfix:
    image: mwader/postfix-relay
    env_file:
      - .env
    volumes:
      - ./docker-volume/opendkim/keys:/etc/opendkim/keys
    restart: "always"

#networks:
#  default:
#    ipam:
#      driver: default
#      config:
#      - subnet: 172.18.0.0/16

volumes:
  assets:
  #certbot-www:
```

My `/opt/pt/PeerTube/.env` file:

```bash
# Database / Postgres service configuration
POSTGRES_USER=pt_mabl_se
POSTGRES_PASSWORD=<my-very-secret-password>
# Postgres database name "peertube"
POSTGRES_DB=peertube
# Editable only with a suffix :
#POSTGRES_DB=peertube_prod
#PEERTUBE_DB_SUFFIX=_prod
PEERTUBE_DB_USERNAME=pt_mabl_se
PEERTUBE_DB_PASSWORD=<my-very-secret-password>
PEERTUBE_DB_SSL=false
# Default to Postgres service name "postgres" in docker-compose.yml
PEERTUBE_DB_HOSTNAME=postgres

# PeerTube server configuration
# If you test PeerTube in local: use "peertube.localhost" and add this domain to your host file resolving on 127.0.0.1
PEERTUBE_WEBSERVER_HOSTNAME=pt.mabl.se
# If you just want to test PeerTube on local
PEERTUBE_WEBSERVER_PORT=443
PEERTUBE_WEBSERVER_HTTPS=true
# If you need more than one IP as trust_proxy
# pass them as a comma separated array:
PEERTUBE_TRUST_PROXY=["127.0.0.1", "loopback", "172.18.0.0/16"]

# Generate one using `openssl rand -hex 32`
PEERTUBE_SECRET=<my-secret-secret>

# E-mail configuration
# If you use a Custom SMTP server
#PEERTUBE_SMTP_USERNAME=
#PEERTUBE_SMTP_PASSWORD=
# Default to Postfix service name "postfix" in docker-compose.yml
# May be the hostname of your Custom SMTP server
PEERTUBE_SMTP_HOSTNAME=postfix
PEERTUBE_SMTP_PORT=25
PEERTUBE_SMTP_FROM=noreply@mabl.se
PEERTUBE_SMTP_TLS=false
PEERTUBE_SMTP_DISABLE_STARTTLS=false
PEERTUBE_ADMIN_EMAIL=pt@mabl.se

# Postfix service configuration
POSTFIX_myhostname=pt@mabl.se
# If you need to generate a list of sub/DOMAIN keys
# pass them as a whitespace separated string <DOMAIN>=<selector>
#OPENDKIM_DOMAINS=pt.mabl.se=peertube
# see https://github.com/wader/postfix-relay/pull/18
OPENDKIM_RequireSafeKeys=no

# /!\ Prefer to use the PeerTube admin interface to set the following configurations /!\
#PEERTUBE_SIGNUP_ENABLED=true
#PEERTUBE_TRANSCODING_ENABLED=true
#PEERTUBE_CONTACT_FORM_ENABLED=true
```

Does it make sense to you, @kontrollanten?

Next we'll add some Nginx cache configurations and see if we can speed it up a bit!